### PR TITLE
Add pharmacy microservice skeleton

### DIFF
--- a/pharmacy-service/README.md
+++ b/pharmacy-service/README.md
@@ -1,0 +1,31 @@
+# Pharmacy Service
+
+This microservice isolates pharmacy functionality from ERPNext and refactors it into a standalone NestJS application aligned with FHIR R4. It provides basic endpoints for managing medications, stock levels, and dispensing logs.
+
+## Running
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Set up environment variables for PostgreSQL connection if needed (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`).
+3. Start the service:
+
+```bash
+npm run start
+```
+
+The service listens on port `3000` by default.
+
+## API Endpoints
+
+- `POST /medications`
+- `GET /medications`
+- `POST /stock`
+- `GET /stock`
+- `POST /dispense`
+- `GET /dispense?patient_id=...`
+
+These endpoints store data in PostgreSQL using TypeORM and loosely map to FHIR resources (Medication, MedicationDispense).

--- a/pharmacy-service/nest-cli.json
+++ b/pharmacy-service/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/pharmacy-service/package.json
+++ b/pharmacy-service/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "pharmacy-service",
+  "version": "0.1.0",
+  "description": "FHIR-aligned pharmacy microservice extracted from ERPNext",
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.2.0",
+    "@nestjs/core": "^10.2.0",
+    "@nestjs/platform-express": "^10.2.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "typeorm": "^0.3.17",
+    "pg": "^8.7.3",
+    "reflect-metadata": "^0.1.13",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.13.2",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.2.1",
+    "@nestjs/schematics": "^10.0.0",
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/pharmacy-service/src/app.module.ts
+++ b/pharmacy-service/src/app.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MedicationModule } from './medication/medication.module';
+import { StockModule } from './stock/stock.module';
+import { DispenseModule } from './dispense/dispense.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: process.env.DB_HOST || 'localhost',
+      port: Number(process.env.DB_PORT) || 5432,
+      username: process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres',
+      database: process.env.DB_NAME || 'pharmacy',
+      autoLoadEntities: true,
+      synchronize: true,
+    }),
+    MedicationModule,
+    StockModule,
+    DispenseModule,
+  ],
+})
+export class AppModule {}

--- a/pharmacy-service/src/dispense/dispense.controller.ts
+++ b/pharmacy-service/src/dispense/dispense.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, Body, Get, Query } from '@nestjs/common';
+import { DispenseService } from './dispense.service';
+import { CreateDispenseDto } from './dto/create-dispense.dto';
+
+@Controller('dispense')
+export class DispenseController {
+  constructor(private readonly service: DispenseService) {}
+
+  @Post()
+  create(@Body() dto: CreateDispenseDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  find(@Query('patient_id') patientId: string) {
+    return this.service.findAllForPatient(patientId);
+  }
+}

--- a/pharmacy-service/src/dispense/dispense.module.ts
+++ b/pharmacy-service/src/dispense/dispense.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Dispense } from './entities/dispense.entity';
+import { DispenseService } from './dispense.service';
+import { DispenseController } from './dispense.controller';
+import { Medication } from '../medication/entities/medication.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Dispense, Medication])],
+  providers: [DispenseService],
+  controllers: [DispenseController],
+})
+export class DispenseModule {}

--- a/pharmacy-service/src/dispense/dispense.service.ts
+++ b/pharmacy-service/src/dispense/dispense.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Dispense } from './entities/dispense.entity';
+import { Medication } from '../medication/entities/medication.entity';
+import { CreateDispenseDto } from './dto/create-dispense.dto';
+
+@Injectable()
+export class DispenseService {
+  constructor(
+    @InjectRepository(Dispense)
+    private dispenses: Repository<Dispense>,
+    @InjectRepository(Medication)
+    private meds: Repository<Medication>,
+  ) {}
+
+  async create(dto: CreateDispenseDto) {
+    const medication = await this.meds.findOneBy({ id: dto.medicationId });
+    const dispense = this.dispenses.create({
+      medication,
+      patientId: dto.patientId,
+      quantity: dto.quantity,
+    });
+    return this.dispenses.save(dispense);
+  }
+
+  findAllForPatient(patientId: string) {
+    return this.dispenses.find({ where: { patientId } });
+  }
+}

--- a/pharmacy-service/src/dispense/dto/create-dispense.dto.ts
+++ b/pharmacy-service/src/dispense/dto/create-dispense.dto.ts
@@ -1,0 +1,12 @@
+import { IsUUID, IsNumber, IsString } from 'class-validator';
+
+export class CreateDispenseDto {
+  @IsUUID()
+  medicationId: string;
+
+  @IsString()
+  patientId: string;
+
+  @IsNumber()
+  quantity: number;
+}

--- a/pharmacy-service/src/dispense/entities/dispense.entity.ts
+++ b/pharmacy-service/src/dispense/entities/dispense.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Medication } from '../../medication/entities/medication.entity';
+
+@Entity()
+export class Dispense {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Medication, { eager: true })
+  medication: Medication;
+
+  @Column()
+  patientId: string; // reference to Patient resource (e.g., via Medplum)
+
+  @Column()
+  quantity: number;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  date: Date;
+}

--- a/pharmacy-service/src/main.ts
+++ b/pharmacy-service/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/pharmacy-service/src/medication/dto/create-medication.dto.ts
+++ b/pharmacy-service/src/medication/dto/create-medication.dto.ts
@@ -1,0 +1,17 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class CreateMedicationDto {
+  @IsString()
+  code: string;
+
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  form?: string;
+
+  @IsOptional()
+  @IsString()
+  manufacturer?: string;
+}

--- a/pharmacy-service/src/medication/entities/medication.entity.ts
+++ b/pharmacy-service/src/medication/entities/medication.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+// FHIR Medication resource (simplified)
+@Entity()
+export class Medication {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  code: string; // medication code or identifier
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  form?: string;
+
+  @Column({ nullable: true })
+  manufacturer?: string;
+}

--- a/pharmacy-service/src/medication/medication.controller.ts
+++ b/pharmacy-service/src/medication/medication.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, Body, Get } from '@nestjs/common';
+import { MedicationService } from './medication.service';
+import { CreateMedicationDto } from './dto/create-medication.dto';
+
+@Controller('medications')
+export class MedicationController {
+  constructor(private readonly service: MedicationService) {}
+
+  @Post()
+  create(@Body() dto: CreateMedicationDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+}

--- a/pharmacy-service/src/medication/medication.module.ts
+++ b/pharmacy-service/src/medication/medication.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Medication } from './entities/medication.entity';
+import { MedicationService } from './medication.service';
+import { MedicationController } from './medication.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Medication])],
+  providers: [MedicationService],
+  controllers: [MedicationController],
+})
+export class MedicationModule {}

--- a/pharmacy-service/src/medication/medication.service.ts
+++ b/pharmacy-service/src/medication/medication.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Medication } from './entities/medication.entity';
+import { CreateMedicationDto } from './dto/create-medication.dto';
+
+@Injectable()
+export class MedicationService {
+  constructor(
+    @InjectRepository(Medication)
+    private meds: Repository<Medication>,
+  ) {}
+
+  create(dto: CreateMedicationDto) {
+    const med = this.meds.create(dto);
+    return this.meds.save(med);
+  }
+
+  findAll() {
+    return this.meds.find();
+  }
+}

--- a/pharmacy-service/src/stock/dto/create-stock.dto.ts
+++ b/pharmacy-service/src/stock/dto/create-stock.dto.ts
@@ -1,0 +1,21 @@
+import { IsString, IsNumber, IsUUID, IsOptional } from 'class-validator';
+
+export class CreateStockDto {
+  @IsUUID()
+  medicationId: string;
+
+  @IsNumber()
+  quantity: number;
+
+  @IsOptional()
+  @IsString()
+  batchNumber?: string;
+
+  @IsOptional()
+  @IsString()
+  warehouse?: string;
+
+  @IsOptional()
+  @IsString()
+  expiry?: string; // ISO date
+}

--- a/pharmacy-service/src/stock/entities/stock.entity.ts
+++ b/pharmacy-service/src/stock/entities/stock.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Medication } from '../../medication/entities/medication.entity';
+
+@Entity()
+export class Stock {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Medication, { eager: true })
+  medication: Medication;
+
+  @Column()
+  quantity: number;
+
+  @Column({ nullable: true })
+  batchNumber?: string;
+
+  @Column({ nullable: true })
+  warehouse?: string;
+
+  @Column({ type: 'date', nullable: true })
+  expiry?: string;
+}

--- a/pharmacy-service/src/stock/stock.controller.ts
+++ b/pharmacy-service/src/stock/stock.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, Body, Get } from '@nestjs/common';
+import { StockService } from './stock.service';
+import { CreateStockDto } from './dto/create-stock.dto';
+
+@Controller('stock')
+export class StockController {
+  constructor(private readonly service: StockService) {}
+
+  @Post()
+  create(@Body() dto: CreateStockDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+}

--- a/pharmacy-service/src/stock/stock.module.ts
+++ b/pharmacy-service/src/stock/stock.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Stock } from './entities/stock.entity';
+import { StockService } from './stock.service';
+import { StockController } from './stock.controller';
+import { Medication } from '../medication/entities/medication.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Stock, Medication])],
+  providers: [StockService],
+  controllers: [StockController],
+})
+export class StockModule {}

--- a/pharmacy-service/src/stock/stock.service.ts
+++ b/pharmacy-service/src/stock/stock.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Stock } from './entities/stock.entity';
+import { Medication } from '../medication/entities/medication.entity';
+import { CreateStockDto } from './dto/create-stock.dto';
+
+@Injectable()
+export class StockService {
+  constructor(
+    @InjectRepository(Stock)
+    private stocks: Repository<Stock>,
+    @InjectRepository(Medication)
+    private meds: Repository<Medication>,
+  ) {}
+
+  async create(dto: CreateStockDto) {
+    const medication = await this.meds.findOneBy({ id: dto.medicationId });
+    const stock = this.stocks.create({
+      medication,
+      quantity: dto.quantity,
+      batchNumber: dto.batchNumber,
+      warehouse: dto.warehouse,
+      expiry: dto.expiry,
+    });
+    return this.stocks.save(stock);
+  }
+
+  findAll() {
+    return this.stocks.find();
+  }
+}

--- a/pharmacy-service/tsconfig.json
+++ b/pharmacy-service/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2019",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- create `pharmacy-service` NestJS application scaffold
- implement Medication, Stock and Dispense modules using TypeORM
- include basic REST controllers and DTOs aligned with FHIR concepts

## Testing
- `npm --version`
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e63071a0832193b22951fbb61a9b